### PR TITLE
렌즈리스트 Tab UI 수정

### DIFF
--- a/lens_review_ios/UI/FreeBoard/BoardListView.swift
+++ b/lens_review_ios/UI/FreeBoard/BoardListView.swift
@@ -16,7 +16,7 @@ struct BoardListView: View {
         {
             ScrollView(showsIndicators: false)
             {
-                VStack(alignment: .leading)
+                LazyVStack(alignment: .leading)
                 {
                     ForEach(boardListViewModel.boardList) { board_ in
                         NavigationLink(destination: FreeBoardDetailView(selectedArticleId: board_.id))

--- a/lens_review_ios/UI/LensDetail/LensDetailView.swift
+++ b/lens_review_ios/UI/LensDetail/LensDetailView.swift
@@ -40,6 +40,8 @@ struct LensDetailView: View
                             .foregroundColor(.gray)
                     }
             }
+            
+            Spacer()
         }
     }
     

--- a/lens_review_ios/UI/LensDetail/LensDetailView.swift
+++ b/lens_review_ios/UI/LensDetail/LensDetailView.swift
@@ -14,10 +14,33 @@ struct LensDetailView: View
     var selectedLensId: Int
     @ObservedObject var lensDetailViewModel: LensDetailViewModel = LensDetailViewModel()
     
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    
     var body: some View {
         VStack{
+            customTitleBar
             LensDetailRow(lens_: lensDetailViewModel.lens)
         }.onAppear(perform: callLensDetail)
+        .frame(maxHeight:.infinity,  alignment: .top)
+        .navigationBarHidden(true)
+    }
+    
+    var customTitleBar : some View {
+        HStack
+        {
+            Button(action: {
+                self.presentationMode.wrappedValue.dismiss()
+                }) {
+                    HStack(spacing: 1) {
+                        Image("arrow-left")
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width:35, height: 35)
+                            .foregroundColor(Color("IconColor"))
+                        Text("돌아가기")
+                            .foregroundColor(.gray)
+                    }
+            }
+        }
     }
     
     func callLensDetail()

--- a/lens_review_ios/UI/LensList/LensListView.swift
+++ b/lens_review_ios/UI/LensList/LensListView.swift
@@ -15,20 +15,21 @@ struct LensListView: View {
     var body: some View {
         NavigationView
         {
-            List
+            ScrollView(showsIndicators: false)
             {
-                ForEach(lensViewModel.lensList) { lens_ in
-                    VStack {
-                        LensListRow(lens_: lens_)
+                LazyVStack(alignment: .leading)
+                {
+                    ForEach(lensViewModel.lensList) { lens_ in
                         NavigationLink(destination: LensDetailView(selectedLensId: lens_.id))
                         {
-                            // NavigationLink 적용 시 화살표 안 뜨게 하기 위함
-                            EmptyView()
+                            LensListRow(lens_: lens_)
                         }
                         .buttonStyle(PlainButtonStyle())
-                    }.frame(minHeight: 100)
+                    }
                 }
+                .frame(minHeight: 100)
             }
+            .padding([.leading, .trailing])
             .navigationBarHidden(true)
         }
         .navigationViewStyle(StackNavigationViewStyle())
@@ -40,35 +41,35 @@ struct LensListRow: View {
     var lens_: LensPreview
     
     var body: some View {
-        HStack {
-            Text("\(lens_.id)")
-            URLImage(url: URL(string: lens_.productImage[0])!) { image in
-                image
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 80, height: 80)
-            }
-            VStack(alignment: .leading) {
-                // TODO : 브랜드명은 보고 없애거나 API에서 받아오도록 수정 필요
-                Text("렌즈 브랜드")
-                    .font(.system(size: 10))
-                    .padding(.bottom, 3)
-                Text(lens_.name)
-                    .font(.system(size: 12))
-                    .padding(.bottom, 5)
-                // TODO : Text 상수 처리, spacing 조절
-                HStack(spacing: 1) {
-                    Text("그래픽 직경: \(lens_.graphicDia, specifier: "%.1f")mm")
+        VStack {
+            HStack {
+                Text("\(lens_.id)")
+                URLImage(url: URL(string: lens_.productImage[0])!) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 80, height: 80)
+                }
+                VStack(alignment: .leading) {
+                    // TODO : 브랜드명은 보고 없애거나 API에서 받아오도록 수정 필요
+                    Text("렌즈 브랜드")
                         .font(.system(size: 10))
-                    Text("| 가격: \(lens_.price)원")
-                        .font(.system(size: 10))
-                    Text("| 평점: ")
-                        .font(.system(size: 10))
-                    Text("4.15")
-                        .font(.system(size: 10))
-                        .foregroundColor(.purple)
+                        .padding(.bottom, 3)
+                    Text(lens_.name)
+                        .font(.system(size: 12))
+                        .padding(.bottom, 5)
+                    // TODO : Text 상수 처리, spacing 조절
+                    HStack(spacing: 1) {
+                        Text("그래픽 직경: \(lens_.graphicDia, specifier: "%.1f")mm")
+                        Text("| 가격: \(lens_.price)원")
+                        Text("| 평점: ")
+                        Text("4.15")
+                            .foregroundColor(.purple)
+                    }.font(.system(size: 10))
                 }
             }
+            
+            Divider()
         }
     }
 }

--- a/lens_review_ios/UI/ReviewBoard/ReviewListView.swift
+++ b/lens_review_ios/UI/ReviewBoard/ReviewListView.swift
@@ -16,7 +16,7 @@ struct ReviewListView: View {
         {
             ScrollView(showsIndicators: false)
             {
-                VStack(alignment: .leading)
+                LazyVStack(alignment: .leading)
                 {
                     ForEach(reviewListViewModel.reviewList) { board_ in
                         NavigationLink(destination: ReviewBoardDetailView(selectedReviewId: board_.id))


### PR DESCRIPTION
resolve https://github.com/wanna-go-home/Issue/issues/20

- 렌즈 목룍 보여주는 방식을 List -> Scrollview 변경
- 디테일 뷰에 커스텀 탭바 적용

바뀌기 전 스샷 : https://github.com/wanna-go-home/lens_review_ios/pull/10
![image](https://user-images.githubusercontent.com/54830720/102088743-ab7ee480-3e5e-11eb-91bb-f109ab558f6b.png)
![image](https://user-images.githubusercontent.com/54830720/102088877-d79a6580-3e5e-11eb-918d-cc00a7099083.png)

